### PR TITLE
[픽스] 식단 펼치기 기능 화살표 방향 문제 해결

### DIFF
--- a/src/pages/Coop/components/DiningBlocks/DiningBlocks.module.scss
+++ b/src/pages/Coop/components/DiningBlocks/DiningBlocks.module.scss
@@ -170,10 +170,9 @@
 }
 
 .arrow-icon {
-  transform: rotate(180deg);
   transition: all 0.4s ease;
 
-  &--close {
-    transform: rotate(0);
+  &--open {
+    transform: rotate(180deg);
   }
 }

--- a/src/pages/Coop/components/DiningBlocks/DiningBlocks.module.scss
+++ b/src/pages/Coop/components/DiningBlocks/DiningBlocks.module.scss
@@ -170,9 +170,10 @@
 }
 
 .arrow-icon {
+  transform: rotate(180deg);
   transition: all 0.4s ease;
 
-  &__transform {
-    transform: rotate(180deg);
+  &--close {
+    transform: rotate(0);
   }
 }

--- a/src/pages/Coop/components/DiningBlocks/index.tsx
+++ b/src/pages/Coop/components/DiningBlocks/index.tsx
@@ -150,7 +150,7 @@ export default function DiningBlocks({ diningType, date }: DiningBlocksProps) {
                   <svg
                     className={cn({
                       [styles['arrow-icon']]: true,
-                      [styles['arrow-icon--close']]: !hiddenDiningIdList.includes(dining.id),
+                      [styles['arrow-icon--open']]: hiddenDiningIdList.includes(dining.id),
                     })}
                     width="20"
                     height="21"

--- a/src/pages/Coop/components/DiningBlocks/index.tsx
+++ b/src/pages/Coop/components/DiningBlocks/index.tsx
@@ -150,7 +150,7 @@ export default function DiningBlocks({ diningType, date }: DiningBlocksProps) {
                   <svg
                     className={cn({
                       [styles['arrow-icon']]: true,
-                      [styles['arrow-icon__transform']]: !hiddenDiningIdList.includes(dining.id),
+                      [styles['arrow-icon--close']]: !hiddenDiningIdList.includes(dining.id),
                     })}
                     width="20"
                     height="21"


### PR DESCRIPTION
- Close #16 
  
## What is this PR? 🔍

- 기능 : 식단 펼치기 기능 화살표 방향 문제 해결
- issue : #16 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
식단 펼치기 기능 화살표 방향 문제를 해결하였습니다.
* 토글 버튼의 클래스명에서 transform 키워드를 close로 변경하였습니다.
* 화살표 방향이 상태와 반대였던 것을 피그마에 맞게 수정하였습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="334" alt="image" src="https://github.com/user-attachments/assets/e69d8770-bc64-4374-ac26-9b21a644f078">

<img width="331" alt="image" src="https://github.com/user-attachments/assets/15a47f27-5fd9-4278-8296-786fb9be7fce">


## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] 식단이 있는 날짜로 가서 토글 버튼 방향이 올바른 지 체크

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
